### PR TITLE
fix: prevent triggering onChange when initialize component

### DIFF
--- a/src/components/StructureEditor.js
+++ b/src/components/StructureEditor.js
@@ -40,7 +40,7 @@ function StructureEditor(props) {
       }
     }
 
-    editorRef.current = { editor, hadFirstChange: false };
+    editorRef.current.editor = editor;
     if (initialMolfile && initialIDCode) {
       throw new Error('Cannot specify both initialMolfile and initialIDCode');
     }

--- a/stories/structure-editor.stories.js
+++ b/stories/structure-editor.stories.js
@@ -8,6 +8,8 @@ export default {
   args: {
     svgMenu: true,
     fragment: false,
+    width: 675,
+    height: 450,
   },
   parameters: {
     docs: {
@@ -38,7 +40,7 @@ Actelion Java MolfileCreator 1.0
 M  END
 `;
 
-export function FromMolfile({ svgMenu, fragment }) {
+export function FromMolfile({ svgMenu, fragment, width, height }) {
   const [molfile, setMolfile] = useState(initialMolfile);
   const [previous, setPrevious] = useState(null);
   const cb = useCallback(
@@ -53,7 +55,7 @@ export function FromMolfile({ svgMenu, fragment }) {
       <h2>Editor</h2>
       <StructureEditor
         initialMolfile={molfile}
-        svgMenu={svgMenu}
+        {...{ svgMenu, width, height }}
         fragment={fragment}
         onChange={cb}
       />
@@ -71,7 +73,7 @@ export function FromMolfile({ svgMenu, fragment }) {
   );
 }
 
-export function FromIDCode({ svgMenu, fragment }) {
+export function FromIDCode({ svgMenu, fragment, width, height }) {
   const [idCode, setIDCode] = useState(initialIDCode);
   const [previous, setPrevious] = useState(null);
   const cb = useCallback(
@@ -86,7 +88,7 @@ export function FromIDCode({ svgMenu, fragment }) {
       <h2>Editor</h2>
       <StructureEditor
         initialIDCode={idCode}
-        svgMenu={svgMenu}
+        {...{ svgMenu, width, height }}
         fragment={fragment}
         onChange={cb}
       />


### PR DESCRIPTION
the structure editor no longer triggers the onChange call-back as supposed to once the editor is re-render because the  `hadFirstChange` is re-initialized every time the component is rendered, which it should not because it is supposed just to prevent the triggering on the first time the component is render. 

In NMRium the problem happens once one of those properties is changed  (width, height) after we initialize the component
